### PR TITLE
ch7. 빈 후처리기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/hello/proxy/ProxyApplication.java
+++ b/src/main/java/hello/proxy/ProxyApplication.java
@@ -1,6 +1,8 @@
 package hello.proxy;
 
 import hello.proxy.config.v3_proxyfactory.ProxyFactoryConfigV2;
+import hello.proxy.config.v4_postprocessor.BeanPostProcessorConfig;
+import hello.proxy.config.v5_autoproxy.AutoProxyConfig;
 import hello.proxy.trace.logtrace.LogTrace;
 import hello.proxy.trace.logtrace.ThreadLocalLogTrace;
 import org.springframework.boot.SpringApplication;
@@ -14,7 +16,9 @@ import org.springframework.context.annotation.Import;
 //@Import(DynamicProxyBasicConfig.class)
 //@Import(DynamicProxyFilterConfig.class)
 //@Import(ProxyFactoryConfigV1.class)
-@Import(ProxyFactoryConfigV2.class)
+//@Import(ProxyFactoryConfigV2.class)
+//@Import(BeanPostProcessorConfig.class)
+@Import(AutoProxyConfig.class)
 @SpringBootApplication(scanBasePackages = "hello.proxy.app") //주의
 public class ProxyApplication {
 

--- a/src/main/java/hello/proxy/config/v4_postprocessor/BeanPostProcessorConfig.java
+++ b/src/main/java/hello/proxy/config/v4_postprocessor/BeanPostProcessorConfig.java
@@ -1,0 +1,35 @@
+package hello.proxy.config.v4_postprocessor;
+
+import hello.proxy.config.AppV1Config;
+import hello.proxy.config.AppV2Config;
+import hello.proxy.config.v3_proxyfactory.advice.LogTraceAdvice;
+import hello.proxy.config.v4_postprocessor.postprocessor.PackageLogTracePostProcessor;
+import hello.proxy.trace.logtrace.LogTrace;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.Advisor;
+import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.aop.support.NameMatchMethodPointcut;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Slf4j
+@Configuration
+@Import({AppV1Config.class, AppV2Config.class})
+public class BeanPostProcessorConfig {
+
+    @Bean
+    public PackageLogTracePostProcessor logTracePostProcessor(LogTrace logTrace){
+        return new PackageLogTracePostProcessor("hello.proxy.app", getAdvisor(logTrace));
+
+    }
+
+    private Advisor getAdvisor(LogTrace logTrace) {
+        //pointcut
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut();
+        pointcut.setMappedNames("request*", "order*", "save*");
+        //advice
+        LogTraceAdvice logTraceAdvice = new LogTraceAdvice(logTrace);
+        return new DefaultPointcutAdvisor(pointcut, logTraceAdvice);
+    }
+}

--- a/src/main/java/hello/proxy/config/v4_postprocessor/postprocessor/PackageLogTracePostProcessor.java
+++ b/src/main/java/hello/proxy/config/v4_postprocessor/postprocessor/PackageLogTracePostProcessor.java
@@ -1,0 +1,42 @@
+package hello.proxy.config.v4_postprocessor.postprocessor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.Advisor;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+@Slf4j
+public class PackageLogTracePostProcessor implements BeanPostProcessor {
+
+    private final String basePackage;
+    private final Advisor advisor;
+
+    public PackageLogTracePostProcessor(String basePackage, Advisor advisor) {
+        this.basePackage = basePackage;
+        this.advisor = advisor;
+    }
+
+    @Override
+    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        log.info("param beanName={} bean={}", beanName, bean.getClass());
+
+        //프록시 적용 대상 여부 체크 (패키지로)
+        //적용 대상 아니면 그냥 원본으루..
+
+        String packageName = bean.getClass().getPackage().getName();
+        if (!packageName.startsWith(basePackage)) {
+            return bean;
+        }
+
+        //프록시 대상이면 프록시를 만들어 반환
+
+        ProxyFactory proxyFactory = new ProxyFactory(bean);
+        proxyFactory.addAdvisor(advisor);
+
+        Object proxy = proxyFactory.getProxy();
+        log.info("create proxy: target={} proxy={}", bean.getClass(), proxy.getClass());
+
+        return proxy;
+    }
+}

--- a/src/main/java/hello/proxy/config/v5_autoproxy/AutoProxyConfig.java
+++ b/src/main/java/hello/proxy/config/v5_autoproxy/AutoProxyConfig.java
@@ -1,0 +1,50 @@
+package hello.proxy.config.v5_autoproxy;
+
+import hello.proxy.config.AppV1Config;
+import hello.proxy.config.AppV2Config;
+import hello.proxy.config.v3_proxyfactory.advice.LogTraceAdvice;
+import hello.proxy.trace.logtrace.LogTrace;
+import org.springframework.aop.Advisor;
+import org.springframework.aop.aspectj.AspectJExpressionPointcut;
+import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.aop.support.NameMatchMethodPointcut;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({AppV1Config.class, AppV2Config.class})
+public class AutoProxyConfig {
+
+//    @Bean
+    public Advisor advisor1(LogTrace logTrace) {
+        //pointcut
+        NameMatchMethodPointcut pointcut = new NameMatchMethodPointcut();
+        pointcut.setMappedNames("request*", "order*", "save*");
+        //advice
+        LogTraceAdvice logTraceAdvice = new LogTraceAdvice(logTrace);
+        return new DefaultPointcutAdvisor(pointcut, logTraceAdvice);
+    }
+
+    //@Bean
+    public Advisor advisor2(LogTrace logTrace) {
+        //pointcut
+        AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
+        pointcut.setExpression("execution(* hello.proxy.app..*(..))");
+
+        //advice
+        LogTraceAdvice logTraceAdvice = new LogTraceAdvice(logTrace);
+        return new DefaultPointcutAdvisor(pointcut, logTraceAdvice);
+    }
+
+    @Bean
+    public Advisor advisor3(LogTrace logTrace) {
+        //pointcut
+        AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
+        pointcut.setExpression("execution(* hello.proxy.app..*(..)) && !execution(* hello.proxy.app..noLog(..))");
+
+        //advice
+        LogTraceAdvice logTraceAdvice = new LogTraceAdvice(logTrace);
+        return new DefaultPointcutAdvisor(pointcut, logTraceAdvice);
+    }
+}

--- a/src/test/java/hello/proxy/postprocessor/BasicTest.java
+++ b/src/test/java/hello/proxy/postprocessor/BasicTest.java
@@ -1,0 +1,52 @@
+package hello.proxy.postprocessor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+public class BasicTest {
+
+    @Test
+    void basicConfig() {
+        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext(BasicConfig.class);
+
+        //A는 등록
+        A a = applicationContext.getBean("beanA", A.class);
+        a.helloA();
+
+        //B는 등록한 적 없음
+        Assertions.assertThrows(NoSuchBeanDefinitionException.class, ()-> applicationContext.getBean(B.class));
+    }
+
+    @Configuration
+    static class BasicConfig {
+
+        @Bean(name = "beanA")
+        public A a() {
+            return new A();
+        }
+
+    }
+
+
+    static class A {
+        public void helloA() {
+            log.info("hello A");
+        }
+    }
+
+
+    static class B {
+        public void helloB() {
+            log.info("hello B");
+        }
+
+    }
+
+
+}

--- a/src/test/java/hello/proxy/postprocessor/BeanPostProcessorTest.java
+++ b/src/test/java/hello/proxy/postprocessor/BeanPostProcessorTest.java
@@ -1,0 +1,73 @@
+package hello.proxy.postprocessor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+public class BeanPostProcessorTest {
+
+    @Test
+    void basicConfig() {
+        AnnotationConfigApplicationContext applicationContext = new AnnotationConfigApplicationContext(BasicConfig.class);
+
+        //A는 등록
+        B b = applicationContext.getBean("beanA", B.class);
+        b.helloB();
+
+        //B는 등록한 적 없음
+        Assertions.assertThrows(NoSuchBeanDefinitionException.class, ()-> applicationContext.getBean(A.class));
+    }
+
+    @Configuration
+    static class BasicConfig {
+
+        @Bean(name = "beanA")
+        public A a() {
+            return new A();
+        }
+
+        @Bean
+        public AToBPostProcessor helloPostProcessor(){
+            return new AToBPostProcessor();
+        }
+
+    }
+
+
+    static class A {
+        public void helloA() {
+            log.info("hello A");
+        }
+    }
+
+
+    static class B {
+        public void helloB() {
+            log.info("hello B");
+        }
+
+    }
+
+    static class AToBPostProcessor implements BeanPostProcessor {
+
+        @Override
+        public Object postProcessAfterInitialization(Object bean, String beanName)
+            throws BeansException {
+            log.info("beanName={} bean={}", beanName, bean);
+            if (bean instanceof A) {
+                return new B();
+            }
+
+            return bean;
+        }
+    }
+
+
+}


### PR DESCRIPTION
빈 후처리기 - 빈 등록 "후" 처리 "등록된 빈 바꿔치기(프록시 등으로)" 할 수 있음.

BeanPostProcessorConfig.class 와 같이 처리해서 등록할 수 있다. (이제 귀찮은거 안해도 된다)

근데 스프링이 제공하는 빈 후처리기 (spring-aop)를 이용하면 더 편하당
스프링 AOP를 쓰면 생성 시 자동으로 프록시를 생성해준당 (advisor를 기준으로 pointCut에 해당하는 넘들을 다 등록..)
생성 단계 말고 사용 단계에서도 포인트컷 보고 판단한다.

글구 여러 advisor 적용하면 그 advisor만큼 프록시 생성하는게 ㅇㅏ니라 하나만 생성한다. ㅇㅋㅇㅋ
 